### PR TITLE
Misc audio player fixes

### DIFF
--- a/mannaggia.sh
+++ b/mannaggia.sh
@@ -25,14 +25,20 @@ ndsflag=false
 wallflag=false
 DELSTRING1="</FONT>"
 DELSTRING2="</b>"
-PLAYER="mplayer -really-quiet -ao alsa"
+DEFPLAYER="mplayer -really-quiet -ao alsa"
+PLAYER="${PLAYER:-$DEFPLAYER}"
 
 # lettura parametri da riga comando
 for parm in "$@"
 	do
 	# leggi dai parametri se c'e' l'audio
 	if [ "$parm" = "--audio" ]
-		then 
+		then
+		# non facciamo stronzate
+		which "$(echo "$PLAYER" | awk '{print $1}')" >/dev/null 2>&1 || {
+			echo "Ok, vuoi l'audio, ma il player dove sta?" >&2
+			exit 255
+		}
 		audioflag=true
 	fi
 
@@ -46,7 +52,7 @@ for parm in "$@"
 	# imposta i santi per minuto e resetta il flag
 	if [ "$spmflag" = true ]
 		then
-		if [ $parm -lt 1 ]
+		if [ "$parm" -lt 1 ]
 			then
 			spm=1
 			spmflag=false


### PR DESCRIPTION
 * let the user override the default audio player using an env var named `PLAYER`
 * check if the player exists (as requested in #8)
 * send death threats to those who don't run shellcheck before committing ;-)