### PR TITLE
added -a switch to grep

### DIFF
--- a/mannaggia.sh
+++ b/mannaggia.sh
@@ -82,7 +82,7 @@ done
 while [ "$nds" != 0 ]
 	do
 	# shellcheck disable=SC2019
-	MANNAGGIA="Mannaggia $(curl -s "www.santiebeati.it/$(</dev/urandom tr -dc A-Z|head -c1)/"|grep tit|cut -d'>' -f 4-9|shuf -n1 |awk -F "$DELSTRING1" '{print$1$2}'|awk -F "$DELSTRING2" '{print$1}')"
+	MANNAGGIA="Mannaggia $(curl -s "www.santiebeati.it/$(</dev/urandom tr -dc A-Z|head -c1)/"|grep -a tit|cut -d'>' -f 4-9|shuf -n1 |awk -F "$DELSTRING1" '{print$1$2}'|awk -F "$DELSTRING2" '{print$1}')"
 	MANNAGGIAURL="http://translate.google.com/translate_tts?tl=it&q=$MANNAGGIA"
 	
 	if [ "$wallflag" = true ]


### PR DESCRIPTION
added -a switch to grep in order to avoid


Fabrizio_DiCarlo@L-235788-P14 ~
$ bash /cygdrive/c/Users/fabrizio_dicarlo/Documents/mannaggia.sh
Mannaggia Binary file (standard input) matches

on Cygwin