### PR TITLE
Espeak support

### DIFF
--- a/mannaggia.sh
+++ b/mannaggia.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ############################################################
 # Mannaggiatore automatico per VUA depressi
 # idea originale by Alexiobash dallo script incazzatore.sh
@@ -17,6 +17,7 @@
 # --nds <n> : numero di santi da invocare (di default continua all'infinito)
 
 audioflag=false
+audiogoogle=true
 spm=1
 spmflag=false
 nds=-1
@@ -27,6 +28,21 @@ DELSTRING1="</FONT>"
 DELSTRING2="</b>"
 PLAYER="mplayer -really-quiet -ao alsa"
 
+espeak_best_voice() {
+	v=$(espeak --voices=it | tail -n +2 | awk '{ print $4 }' | grep -v mbrola | head -n1)
+	if [[ -n "$v" ]]; then
+		echo "-v $v -k10 -g1 -p 30"
+		return
+	fi
+	v=$(espeak --voices=it | tail -n +2 | awk '{ print $4 }' | head -n1)
+	if [[ -n "$v" ]]; then
+		echo "-v $v"
+		return
+	fi
+	echo " "
+}
+ESPEAK="espeak $(espeak_best_voice)"
+
 # lettura parametri da riga comando
 for parm in "$@"
 	do
@@ -34,6 +50,12 @@ for parm in "$@"
 	if [ "$parm" = "--audio" ]
 		then 
 		audioflag=true
+	fi
+	if [ "$parm" = "--google" ] then 
+		audiogoogle=true
+	fi
+	if [ "$parm" = "--espeak" ] then 
+		audiogoogle=false
 	fi
 
 	# leggi dai parametri se c'e' da mandare i commenti su wall
@@ -101,7 +123,12 @@ while [ "$nds" != 0 ]
 
 	if [ "$audioflag" = true ]
 		then
-		$PLAYER "$MANNAGGIAURL" 2>/dev/null
+			if [ "$audiogoogle" = true ]
+			then
+				$PLAYER "$MANNAGGIAURL" 2>/dev/null
+			else
+				$ESPEAK "$MANNAGGIA" 2> /dev/null
+			fi
 	fi
 
 	sleep "$spm"

--- a/mannaggia.sh
+++ b/mannaggia.sh
@@ -43,6 +43,19 @@ espeak_best_voice() {
 }
 ESPEAK="espeak $(espeak_best_voice)"
 
+vocalizza() {
+	if [ "$audioflag" = true ]
+	then
+		if [ "$audiogoogle" = true ]
+		then
+			MANNAGGIAURL="http://translate.google.com/translate_tts?tl=it&q=$1"
+			$PLAYER "$MANNAGGIAURL" 2>/dev/null
+		else
+			$ESPEAK "$1" 2> /dev/null
+		fi
+	fi
+}
+
 # lettura parametri da riga comando
 for parm in "$@"
 	do
@@ -51,10 +64,10 @@ for parm in "$@"
 		then 
 		audioflag=true
 	fi
-	if [ "$parm" = "--google" ] then 
+	if [ "$parm" = "--google" ]; then 
 		audiogoogle=true
 	fi
-	if [ "$parm" = "--espeak" ] then 
+	if [ "$parm" = "--espeak" ]; then 
 		audiogoogle=false
 	fi
 
@@ -105,7 +118,6 @@ while [ "$nds" != 0 ]
 	do
 	# shellcheck disable=SC2019
 	MANNAGGIA="Mannaggia $(curl -s "www.santiebeati.it/$(</dev/urandom tr -dc A-Z|head -c1)/"|grep tit|cut -d'>' -f 4-9|shuf -n1 |awk -F "$DELSTRING1" '{print$1$2}'|awk -F "$DELSTRING2" '{print$1}')"
-	MANNAGGIAURL="http://translate.google.com/translate_tts?tl=it&q=$MANNAGGIA"
 	
 	if [ "$wallflag" = true ]
 		then
@@ -121,16 +133,7 @@ while [ "$nds" != 0 ]
 		echo "$MANNAGGIA" > /dev/stdout
 	fi
 
-	if [ "$audioflag" = true ]
-		then
-			if [ "$audiogoogle" = true ]
-			then
-				$PLAYER "$MANNAGGIAURL" 2>/dev/null
-			else
-				$ESPEAK "$MANNAGGIA" 2> /dev/null
-			fi
-	fi
-
+	vocalizza "$MANNAGGIA"
 	sleep "$spm"
 	nds=$((nds - 1))
 done


### PR DESCRIPTION
I got banned by google, so I wrote this patch that seems to me of general interest.

With `--espeak` you can use espeak: the default is still google. You can, however, be more explicit with `--google`.

They only make sense if you use `--audio`.

I also did some minor refactoring of the audio-related code.