### PR TITLE
Fix sull'iconv da ISO-8859-1 a UTF-8 per le lettere accentate

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,14 @@ Progetto originale:
 - Thanks to: Veteran Unix Admins group on Facebook
 
 
+Android App
+=========
+
+## mannaggia.apk
+App Android sviluppata da Opus 4.6 extended partendo dallo script. Testata su Google Pixel 9 Pro e Android 16.
+L'app prevede la possibilità di usare il text-to-speech di Google, di triggerare un "Mannaggia" scuotendo il telefono (con l'app aperta) e include un widget col quale interagire direttamente dalla home screen. 
+
+## mannaggia-android 
+
+
+Nella cartella sono disponibili i file per poter testare ed effettuare la build dell'app su Android SDK.

--- a/mannaggia-android/.gitignore
+++ b/mannaggia-android/.gitignore
@@ -1,0 +1,10 @@
+*.iml
+.gradle/
+/local.properties
+/.idea/
+.DS_Store
+/build
+/captures
+.externalNativeBuild
+.cxx
+local.properties

--- a/mannaggia-android/README.md
+++ b/mannaggia-android/README.md
@@ -1,0 +1,120 @@
+# Mannaggia — Android port
+
+Android port of [`mannaggia.sh`](https://github.com/LegolasTheElf/mannaggia/blob/master/mannaggia.sh) —
+the automatic saint-invoker for depressed Veteran Unix Admins.
+
+Tap the button → the app scrapes **santiebeati.it**, picks a random saint,
+and shows you `Mannaggia <Saint>!`. Flip the **Pronuncia** toggle to also
+hear it spoken via Google Translate TTS in Italian.
+
+## Ways to invoke a saint
+
+- **In-app button** — tap `Mannaggia!` on the main screen.
+- **Shake the phone** — sharp movement (>2.7 G) while the app is in the
+  foreground triggers a new invocation. 1.5 s cooldown prevents spam.
+- **Quick Settings tile** — long-press the notification shade, edit tiles,
+  drag **Mannaggia** into your active tiles. One tap from anywhere in the
+  system fetches a saint and shows it as a notification.
+- **Home screen widget** — long-press the home screen → **Widgets** →
+  find **Mannaggia** → drag it somewhere. Tap it to re-roll; the text
+  updates in place.
+
+## What was ported
+
+| bash | Kotlin/Android |
+| --- | --- |
+| `curl` | `HttpURLConnection` |
+| `iconv -f ISO-8859-1` | `String(bytes, Charsets.ISO_8859_1)` |
+| `awk -F'…'` | `line.split(Regex("…"))` |
+| `shuf -n1` | `List<String>.random()` |
+| `mplayer <tts url>` | `MediaPlayer` pointed at the same Google TTS URL |
+| CLI flags (`--spm`, `--nds`, `--wall`, `--shutdown` …) | **Not ported** — they don't make sense on a phone |
+
+## Requirements
+
+- **Android Studio** Hedgehog (2023.1) or newer — easiest path
+- OR: JDK 17 + Android command-line tools + a local `gradle` ≥ 8.5
+
+Target: Android 7.0 (API 24) and up.
+
+## Build — easy path (Android Studio)
+
+1. Unzip the project.
+2. **File → Open** → select the `mannaggia-android` folder.
+3. Let Gradle sync (first time downloads ~500 MB of Android deps).
+4. **Build → Build Bundle(s) / APK(s) → Build APK(s)**.
+5. When done, click **locate** in the toast — you'll find
+   `app/build/outputs/apk/debug/app-debug.apk`.
+6. Copy it to your phone and install (enable "Install unknown apps" first).
+
+## Build — command-line path
+
+From inside the project folder:
+
+```sh
+# one-time: generate the gradle wrapper (requires a system gradle ≥ 8.5)
+gradle wrapper --gradle-version 8.5
+
+# then every build:
+./gradlew assembleDebug
+# APK ends up at: app/build/outputs/apk/debug/app-debug.apk
+```
+
+For a signed release build:
+
+```sh
+./gradlew assembleRelease
+# you'll need to configure a keystore in app/build.gradle.kts first
+```
+
+## Build — CI path (no local setup)
+
+1. Create a new GitHub repo and push this folder.
+2. Add `.github/workflows/build.yml`:
+
+   ```yaml
+   name: Build APK
+   on: [push, workflow_dispatch]
+   jobs:
+     build:
+       runs-on: ubuntu-latest
+       steps:
+         - uses: actions/checkout@v4
+         - uses: actions/setup-java@v4
+           with: { distribution: temurin, java-version: '17' }
+         - uses: gradle/actions/setup-gradle@v3
+         - run: gradle wrapper --gradle-version 8.5
+         - run: ./gradlew assembleDebug
+         - uses: actions/upload-artifact@v4
+           with:
+             name: app-debug
+             path: app/build/outputs/apk/debug/app-debug.apk
+   ```
+
+3. Push → go to **Actions** tab → download the APK artifact.
+
+## Install on your phone
+
+1. Transfer the APK to the device (USB, email, Drive, whatever).
+2. On the phone, tap the APK file.
+3. Android will ask you to allow "Install unknown apps" for that source
+   (Settings → Apps → Special access → Install unknown apps).
+4. Done.
+
+## Known caveats
+
+- **Parsing fragility.** The script (and this port) parse
+  `santiebeati.it`'s HTML using very specific `<FONT>` tag patterns.
+  If the site ever redesigns, both the original script AND this app
+  break. There's a `"Sant'Anonimo"` fallback if nothing is found.
+- **Cleartext traffic allowed** (`usesCleartextTraffic="true"`) in case
+  the site ever drops to HTTP. It currently serves over HTTPS.
+- **Google TTS** is an unofficial, undocumented endpoint. If Google
+  changes it (again), audio will silently fail — text-only still works.
+- Dropped CLI features: `--audio` (replaced by the in-app toggle),
+  `--spm` / `--nds` / `--wall` / `--shutdown` / `--off`
+  (nonsensical on a phone).
+
+## License
+
+Same as the upstream script: **GPL-3.0**.

--- a/mannaggia-android/app/build.gradle.kts
+++ b/mannaggia-android/app/build.gradle.kts
@@ -1,0 +1,49 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.mannaggia.app"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.mannaggia.app"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+
+    buildFeatures {
+        viewBinding = true
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.appcompat:appcompat:1.6.1")
+    implementation("com.google.android.material:material:1.11.0")
+    implementation("androidx.constraintlayout:constraintlayout:2.1.4")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+}

--- a/mannaggia-android/app/proguard-rules.pro
+++ b/mannaggia-android/app/proguard-rules.pro
@@ -1,0 +1,1 @@
+# Add project specific ProGuard rules here.

--- a/mannaggia-android/app/src/main/AndroidManifest.xml
+++ b/mannaggia-android/app/src/main/AndroidManifest.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
+
+    <application
+        android:allowBackup="true"
+        android:icon="@drawable/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@drawable/ic_launcher"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.Mannaggia"
+        android:usesCleartextTraffic="true">
+
+        <activity
+            android:name=".MainActivity"
+            android:exported="true">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+
+        <!-- Quick Settings Tile -->
+        <service
+            android:name=".MannaggiaTileService"
+            android:exported="true"
+            android:icon="@drawable/ic_notification"
+            android:label="@string/tile_label"
+            android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
+            <intent-filter>
+                <action android:name="android.service.quicksettings.action.QS_TILE" />
+            </intent-filter>
+        </service>
+
+        <!-- Home Screen Widget -->
+        <receiver
+            android:name=".MannaggiaWidgetProvider"
+            android:exported="true"
+            android:label="@string/app_name">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+                <action android:name="com.mannaggia.app.ACTION_INVOKE_WIDGET" />
+            </intent-filter>
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/mannaggia_widget_info" />
+        </receiver>
+
+    </application>
+</manifest>

--- a/mannaggia-android/app/src/main/java/com/mannaggia/app/MainActivity.kt
+++ b/mannaggia-android/app/src/main/java/com/mannaggia/app/MainActivity.kt
@@ -1,0 +1,127 @@
+package com.mannaggia.app
+
+import android.Manifest
+import android.content.Context
+import android.content.pm.PackageManager
+import android.hardware.Sensor
+import android.hardware.SensorManager
+import android.media.MediaPlayer
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.view.View
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.lifecycleScope
+import com.mannaggia.app.databinding.ActivityMainBinding
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import java.net.URLEncoder
+
+/**
+ * Main screen: tap the button (or shake the phone) to invoke a saint.
+ */
+class MainActivity : AppCompatActivity() {
+
+    private lateinit var binding: ActivityMainBinding
+    private var mediaPlayer: MediaPlayer? = null
+
+    private lateinit var sensorManager: SensorManager
+    private var accelerometer: Sensor? = null
+    private lateinit var shakeDetector: ShakeDetector
+    private var currentJob: Job? = null
+
+    private val requestNotifPermission =
+        registerForActivityResult(ActivityResultContracts.RequestPermission()) { /* no-op */ }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMainBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        binding.btnMannaggia.setOnClickListener { invokeSaint() }
+
+        sensorManager = getSystemService(Context.SENSOR_SERVICE) as SensorManager
+        accelerometer = sensorManager.getDefaultSensor(Sensor.TYPE_ACCELEROMETER)
+        shakeDetector = ShakeDetector { invokeSaint() }
+
+        askForNotificationPermissionIfNeeded()
+    }
+
+    override fun onResume() {
+        super.onResume()
+        accelerometer?.let {
+            sensorManager.registerListener(shakeDetector, it, SensorManager.SENSOR_DELAY_UI)
+        }
+    }
+
+    override fun onPause() {
+        super.onPause()
+        sensorManager.unregisterListener(shakeDetector)
+    }
+
+    private fun invokeSaint() {
+        // Ignore re-entrant triggers while an invocation is still in flight.
+        if (currentJob?.isActive == true) return
+
+        binding.progress.visibility = View.VISIBLE
+        binding.btnMannaggia.isEnabled = false
+        binding.txtResult.text = ""
+
+        currentJob = lifecycleScope.launch {
+            val result = runCatching { Mannaggia.fetchRandomSaint() }
+            result.fold(
+                onSuccess = { saint ->
+                    val phrase = Mannaggia.phraseOf(saint)
+                    binding.txtResult.text = phrase
+                    if (binding.chkAudio.isChecked) speakWithGoogleTts(phrase)
+                },
+                onFailure = { e -> binding.txtResult.text = "Errore: ${e.message}" }
+            )
+            binding.progress.visibility = View.GONE
+            binding.btnMannaggia.isEnabled = true
+        }
+    }
+
+    // ---------------------------------------------------------------
+    // Google Translate TTS (same endpoint the bash `say()` uses)
+    // ---------------------------------------------------------------
+
+    private fun speakWithGoogleTts(text: String) {
+        releasePlayer()
+        val encoded = URLEncoder.encode(text, "UTF-8")
+        val url =
+            "https://translate.google.com/translate_tts?ie=UTF-8&client=tw-ob&q=$encoded&tl=it"
+        try {
+            mediaPlayer = MediaPlayer().apply {
+                val headers = mapOf("User-Agent" to "Mozilla/5.0")
+                setDataSource(this@MainActivity, Uri.parse(url), headers)
+                setOnPreparedListener { start() }
+                setOnCompletionListener { releasePlayer() }
+                setOnErrorListener { _, _, _ -> releasePlayer(); true }
+                prepareAsync()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
+    }
+
+    private fun releasePlayer() {
+        mediaPlayer?.release()
+        mediaPlayer = null
+    }
+
+    private fun askForNotificationPermissionIfNeeded() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU) return
+        val granted = ContextCompat.checkSelfPermission(
+            this, Manifest.permission.POST_NOTIFICATIONS
+        ) == PackageManager.PERMISSION_GRANTED
+        if (!granted) requestNotifPermission.launch(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    override fun onDestroy() {
+        releasePlayer()
+        super.onDestroy()
+    }
+}

--- a/mannaggia-android/app/src/main/java/com/mannaggia/app/Mannaggia.kt
+++ b/mannaggia-android/app/src/main/java/com/mannaggia/app/Mannaggia.kt
@@ -1,0 +1,69 @@
+package com.mannaggia.app
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import java.net.HttpURLConnection
+import java.net.URL
+import kotlin.random.Random
+
+/**
+ * Shared scraping logic — the port of mannaggia.sh lives here so it can be
+ * called from MainActivity, MannaggiaTileService and MannaggiaWidgetProvider.
+ */
+object Mannaggia {
+
+    /** Build the final phrase shown to the user. */
+    fun phraseOf(saint: String): String = "Mannaggia $saint!"
+
+    /** Pick a random letter → scrape santiebeati.it → return a saint name. */
+    suspend fun fetchRandomSaint(): String = withContext(Dispatchers.IO) {
+        val letter = ('A'..'Z').random()
+        val baseUrl = "https://www.santiebeati.it/$letter/"
+
+        // awk -F'more|\.html' '/Pagina:/{print $(NF-1); exit}'
+        val indexHtml = httpGet(baseUrl)
+        val pages = indexHtml.lineSequence()
+            .firstOrNull { "Pagina:" in it }
+            ?.split(Regex("""more|\.html"""))
+            ?.let { parts -> parts.getOrNull(parts.size - 2) }
+            ?.trim()
+            ?.toIntOrNull()
+            ?: 1
+
+        val page = if (pages > 1) Random.nextInt(1, pages + 1) else 1
+        val pageUrl = if (page == 1) baseUrl else "${baseUrl}more$page.html"
+
+        // awk -F'<FONT SIZE="-2">|</FONT> <FONT SIZE="-1"><b>|</b>' \
+        //     '/<a href="\/dettaglio\/.*<FONT/{print $2,$3}'
+        val pageHtml = httpGet(pageUrl)
+        val lineFilter = Regex("""<a href="/dettaglio/.*<FONT""")
+        val fieldSep = Regex("""<FONT SIZE="-2">|</FONT> <FONT SIZE="-1"><b>|</b>""")
+
+        val saints = pageHtml.lineSequence()
+            .filter { lineFilter.containsMatchIn(it) }
+            .mapNotNull { line ->
+                val parts = line.split(fieldSep)
+                if (parts.size >= 3) "${parts[1]} ${parts[2]}".trim() else null
+            }
+            .filter { it.isNotBlank() }
+            .toList()
+
+        if (saints.isEmpty()) "Sant'Anonimo" else saints.random()
+    }
+
+    /** HTTP GET decoded as UTF-8 (equivalent to `iconv -f UTF-8`). */
+    private fun httpGet(urlStr: String): String {
+        val conn = (URL(urlStr).openConnection() as HttpURLConnection).apply {
+            requestMethod = "GET"
+            setRequestProperty("User-Agent", "Mozilla/5.0 Mannaggia-Android")
+            connectTimeout = 10_000
+            readTimeout = 15_000
+        }
+        try {
+            val bytes = conn.inputStream.use { it.readBytes() }
+            return String(bytes, Charsets.UTF_8)
+        } finally {
+            conn.disconnect()
+        }
+    }
+}

--- a/mannaggia-android/app/src/main/java/com/mannaggia/app/MannaggiaTileService.kt
+++ b/mannaggia-android/app/src/main/java/com/mannaggia/app/MannaggiaTileService.kt
@@ -1,0 +1,93 @@
+package com.mannaggia.app
+
+import android.Manifest
+import android.app.NotificationChannel
+import android.app.NotificationManager
+import android.app.PendingIntent
+import android.content.Intent
+import android.content.pm.PackageManager
+import android.os.Build
+import android.service.quicksettings.Tile
+import android.service.quicksettings.TileService
+import androidx.core.app.NotificationCompat
+import androidx.core.content.ContextCompat
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Quick Settings tile. One tap → fetch a saint → post a notification
+ * with the phrase. Tapping the notification opens the app.
+ */
+class MannaggiaTileService : TileService() {
+
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+
+    override fun onClick() {
+        super.onClick()
+        setTileState(Tile.STATE_ACTIVE)
+
+        scope.launch {
+            val phrase = runCatching { Mannaggia.phraseOf(Mannaggia.fetchRandomSaint()) }
+                .getOrElse { "Errore: ${it.message}" }
+            showNotification(phrase)
+            setTileState(Tile.STATE_INACTIVE)
+        }
+    }
+
+    override fun onStartListening() {
+        super.onStartListening()
+        setTileState(Tile.STATE_INACTIVE)
+    }
+
+    private fun setTileState(state: Int) {
+        qsTile?.apply {
+            this.state = state
+            updateTile()
+        }
+    }
+
+    private fun showNotification(phrase: String) {
+        // Need runtime POST_NOTIFICATIONS on API 33+. Silently skip if missing.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            val granted = ContextCompat.checkSelfPermission(
+                this, Manifest.permission.POST_NOTIFICATIONS
+            ) == PackageManager.PERMISSION_GRANTED
+            if (!granted) return
+        }
+
+        val nm = getSystemService(NotificationManager::class.java) ?: return
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            val channel = NotificationChannel(
+                CHANNEL_ID, "Mannaggia", NotificationManager.IMPORTANCE_DEFAULT
+            )
+            nm.createNotificationChannel(channel)
+        }
+
+        val intent = Intent(this, MainActivity::class.java).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK)
+        }
+        val pending = PendingIntent.getActivity(
+            this, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+
+        val notification = NotificationCompat.Builder(this, CHANNEL_ID)
+            .setContentTitle("Mannaggia!")
+            .setContentText(phrase)
+            .setStyle(NotificationCompat.BigTextStyle().bigText(phrase))
+            .setSmallIcon(R.drawable.ic_notification)
+            .setContentIntent(pending)
+            .setAutoCancel(true)
+            .build()
+
+        nm.notify(NOTIF_ID, notification)
+    }
+
+    companion object {
+        private const val CHANNEL_ID = "mannaggia"
+        private const val NOTIF_ID = 1
+    }
+}

--- a/mannaggia-android/app/src/main/java/com/mannaggia/app/MannaggiaWidgetProvider.kt
+++ b/mannaggia-android/app/src/main/java/com/mannaggia/app/MannaggiaWidgetProvider.kt
@@ -1,0 +1,80 @@
+package com.mannaggia.app
+
+import android.app.PendingIntent
+import android.appwidget.AppWidgetManager
+import android.appwidget.AppWidgetProvider
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.widget.RemoteViews
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.launch
+
+/**
+ * Home screen widget. Tap the widget → fetch a saint → widget text updates
+ * in place. No notification, no app launch.
+ */
+class MannaggiaWidgetProvider : AppWidgetProvider() {
+
+    override fun onUpdate(
+        context: Context,
+        appWidgetManager: AppWidgetManager,
+        appWidgetIds: IntArray
+    ) {
+        for (id in appWidgetIds) {
+            render(context, appWidgetManager, id, text = null)
+        }
+    }
+
+    override fun onReceive(context: Context, intent: Intent) {
+        super.onReceive(context, intent)
+        if (intent.action != ACTION_INVOKE) return
+
+        val mgr = AppWidgetManager.getInstance(context)
+        val component = ComponentName(context, MannaggiaWidgetProvider::class.java)
+        val ids = mgr.getAppWidgetIds(component)
+        if (ids.isEmpty()) return
+
+        // Show loading state in every instance of the widget.
+        for (id in ids) render(context, mgr, id, text = "…")
+
+        // Run the fetch asynchronously; goAsync keeps the BroadcastReceiver alive.
+        val pendingResult = goAsync()
+        CoroutineScope(SupervisorJob() + Dispatchers.IO).launch {
+            val phrase = runCatching { Mannaggia.phraseOf(Mannaggia.fetchRandomSaint()) }
+                .getOrElse { "Errore" }
+            try {
+                for (id in ids) render(context, mgr, id, text = phrase)
+            } finally {
+                pendingResult.finish()
+            }
+        }
+    }
+
+    private fun render(
+        context: Context,
+        mgr: AppWidgetManager,
+        widgetId: Int,
+        text: String?
+    ) {
+        val views = RemoteViews(context.packageName, R.layout.widget_mannaggia)
+        if (text != null) views.setTextViewText(R.id.widget_text, text)
+
+        val intent = Intent(context, MannaggiaWidgetProvider::class.java).apply {
+            action = ACTION_INVOKE
+        }
+        val pending = PendingIntent.getBroadcast(
+            context, 0, intent,
+            PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_IMMUTABLE
+        )
+        views.setOnClickPendingIntent(R.id.widget_root, pending)
+
+        mgr.updateAppWidget(widgetId, views)
+    }
+
+    companion object {
+        private const val ACTION_INVOKE = "com.mannaggia.app.ACTION_INVOKE_WIDGET"
+    }
+}

--- a/mannaggia-android/app/src/main/java/com/mannaggia/app/ShakeDetector.kt
+++ b/mannaggia-android/app/src/main/java/com/mannaggia/app/ShakeDetector.kt
@@ -1,0 +1,36 @@
+package com.mannaggia.app
+
+import android.hardware.Sensor
+import android.hardware.SensorEvent
+import android.hardware.SensorEventListener
+import android.hardware.SensorManager
+import kotlin.math.sqrt
+
+/**
+ * Fires [onShake] when the device experiences a sharp movement
+ * above [SHAKE_THRESHOLD_G]×gravity. Has a cooldown so a single
+ * shake doesn't trigger multiple invocations.
+ */
+class ShakeDetector(private val onShake: () -> Unit) : SensorEventListener {
+
+    private var lastShakeMs = 0L
+
+    override fun onSensorChanged(event: SensorEvent) {
+        if (event.sensor.type != Sensor.TYPE_ACCELEROMETER) return
+        val (x, y, z) = Triple(event.values[0], event.values[1], event.values[2])
+        val gForce = sqrt(x * x + y * y + z * z) / SensorManager.GRAVITY_EARTH
+        if (gForce > SHAKE_THRESHOLD_G) {
+            val now = System.currentTimeMillis()
+            if (now - lastShakeMs < COOLDOWN_MS) return
+            lastShakeMs = now
+            onShake()
+        }
+    }
+
+    override fun onAccuracyChanged(sensor: Sensor?, accuracy: Int) = Unit
+
+    companion object {
+        private const val SHAKE_THRESHOLD_G = 2.7f
+        private const val COOLDOWN_MS = 1_500L
+    }
+}

--- a/mannaggia-android/app/src/main/res/drawable/ic_launcher.xml
+++ b/mannaggia-android/app/src/main/res/drawable/ic_launcher.xml
@@ -1,0 +1,12 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="108dp"
+    android:height="108dp"
+    android:viewportWidth="108"
+    android:viewportHeight="108">
+    <path
+        android:fillColor="#8B0000"
+        android:pathData="M0,0h108v108h-108z" />
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M54,26 L38,80 L46,80 L50,66 L58,66 L62,80 L70,80 Z M52,58 L54,46 L56,58 Z" />
+</vector>

--- a/mannaggia-android/app/src/main/res/drawable/ic_notification.xml
+++ b/mannaggia-android/app/src/main/res/drawable/ic_notification.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="#FFFFFF"
+        android:pathData="M4,4 L7,20 L10,20 L12,10 L14,20 L17,20 L20,4 L17,4 L15.5,13 L13.5,4 L10.5,4 L8.5,13 L7,4 Z" />
+</vector>

--- a/mannaggia-android/app/src/main/res/drawable/widget_background.xml
+++ b/mannaggia-android/app/src/main/res/drawable/widget_background.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
+    <solid android:color="#8B0000" />
+    <corners android:radius="16dp" />
+</shape>

--- a/mannaggia-android/app/src/main/res/layout/activity_main.xml
+++ b/mannaggia-android/app/src/main/res/layout/activity_main.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/txtResult"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:textSize="28sp"
+        android:text=""
+        app:layout_constraintBottom_toTopOf="@id/btnMannaggia"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/btnMannaggia"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:text="@string/btn_mannaggia"
+        app:layout_constraintBottom_toTopOf="@id/progress"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <ProgressBar
+        android:id="@+id/progress"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="16dp"
+        android:visibility="gone"
+        app:layout_constraintBottom_toTopOf="@id/chkAudio"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+    <CheckBox
+        android:id="@+id/chkAudio"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="24dp"
+        android:text="@string/chk_audio"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/mannaggia-android/app/src/main/res/layout/widget_mannaggia.xml
+++ b/mannaggia-android/app/src/main/res/layout/widget_mannaggia.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/widget_root"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@drawable/widget_background"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <TextView
+        android:id="@+id/widget_text"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/widget_default_text"
+        android:textColor="#FFFFFF"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+</LinearLayout>

--- a/mannaggia-android/app/src/main/res/values/strings.xml
+++ b/mannaggia-android/app/src/main/res/values/strings.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Mannaggia</string>
+    <string name="btn_mannaggia">Mannaggia!</string>
+    <string name="chk_audio">Pronuncia (Google TTS)</string>
+    <string name="widget_default_text">Mannaggia!</string>
+    <string name="tile_label">Mannaggia</string>
+</resources>

--- a/mannaggia-android/app/src/main/res/values/themes.xml
+++ b/mannaggia-android/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <style name="Theme.Mannaggia" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">#8B0000</item>
+        <item name="colorOnPrimary">#FFFFFF</item>
+    </style>
+</resources>

--- a/mannaggia-android/app/src/main/res/xml/mannaggia_widget_info.xml
+++ b/mannaggia-android/app/src/main/res/xml/mannaggia_widget_info.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:initialLayout="@layout/widget_mannaggia"
+    android:minWidth="110dp"
+    android:minHeight="40dp"
+    android:resizeMode="horizontal|vertical"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />

--- a/mannaggia-android/build.gradle.kts
+++ b/mannaggia-android/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/mannaggia-android/gradle.properties
+++ b/mannaggia-android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+kotlin.code.style=official
+android.nonTransitiveRClass=true

--- a/mannaggia-android/gradle/wrapper/gradle-wrapper.properties
+++ b/mannaggia-android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/mannaggia-android/settings.gradle.kts
+++ b/mannaggia-android/settings.gradle.kts
@@ -1,0 +1,16 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+rootProject.name = "Mannaggia"
+include(":app")

--- a/mannaggia.sh
+++ b/mannaggia.sh
@@ -133,7 +133,7 @@ while [ "$nds" != 0 ]
 		[ $page -ne 1 ] && path=more$page.html
 	fi
 
-	MANNAGGIA="Mannaggia $(curl -s "https://www.santiebeati.it/$letter/$path" | awk -F'<FONT SIZE="-2">|</FONT> <FONT SIZE="-1"><b>|</b>' '/<a href="\/dettaglio\/.*<FONT/{print $2,$3}' | iconv -f ISO-8859-1| $shufCmd -n1)"
+	MANNAGGIA="Mannaggia $(curl -s "https://www.santiebeati.it/$letter/$path" | awk -F'<FONT SIZE="-2">|</FONT> <FONT SIZE="-1"><b>|</b>' '/<a href="\/dettaglio\/.*<FONT/{print $2,$3}' | iconv -f UTF-8| $shufCmd -n1)"
 	if [ "$wallflag" = true ]
 		then
 		pot=$(( nds % 50 ))


### PR DESCRIPTION
Utilizzando iconv con il flag -f da ISO-8859-1 vengono generate lettere strane al posto di quelle accentate, cambiando il charset in UTF-8 il problema non si pone.